### PR TITLE
DB設計 Usersテーブルカラム型変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Things you may want to cover:
 |first_name      |string    |null: false|
 |last_name_kana  |string    |null: false|
 |first_name_kana |string    |null: false|
-|birth_year      |integer   |null: false|
-|birth_month     |integer   |null: false|
-|birth_day       |integer   |null: false|
+|birthday        |date      |null: false|
 
 ### Association
 - has_one  :destination, dependent: :destroy


### PR DESCRIPTION
# what
Usersテーブルの登録ユーザーの生年月日の型をinteger型からdate型へ変更

# why
ユーザー登録画面の生年月日欄の実装にdate_selectタグを活用することにより、
実装を簡潔にし、可読性を向上させるため。
date_selectタグはdate型のデータを扱うことが原則である為、変更が必要。