### PR TITLE
DB設計変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Things you may want to cover:
 |city            |string    |null: false|
 |block           |string    |null: false|
 |building        |string    |null: false|
-|phone_number    |integer   |           |
+|phone_number    |string    |           |
 |user_id         |references|null: false, foreign_key: true|
 
 ### Association
@@ -65,13 +65,11 @@ Things you may want to cover:
 
 
 ## credit_cards table
-|Column           |Type      |Options    |
-|-----------------|----------|-----------|
-|card_number      |integer   |null: false|
-|expiration_year  |integer   |null: false|
-|expiration_month |integer   |null: false|
-|security_code    |integer   |null: false|
-|user_id          |references|null: false, foreign_key: true|
+|Column      |Type      |Options    |
+|------------|----------|-----------|
+|card_id     |string	  |null:false |
+|customer_id |string	  |null:false |
+|user_id     |references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to  :user
@@ -134,7 +132,7 @@ Things you may want to cover:
 |Column   |Type   |Options     |
 |---------|-------|------------|
 |name     |string |null: false |
-|ancestry |string |null: false |
+|ancestry |string |            |
 
 ### Association
 - has_many :products


### PR DESCRIPTION
# what
下記の変更をテーブルに実施した。
　送付先情報テーブル
　　phone_number integerからstringへ変更
　カテゴリーテーブル
　　ancestry　null:falseを削除(子がない場合nullとなるため)
　クレジットカードテーブル
　　payjpに合わせて下記カラムへ
　　　card_id string
　　　customer_id string

# why
　サーバサイド実装時にエラーを生じさせないため。
　string型で扱う必要がある項目、nullの許可が必要な項目、顧客の秘匿情報を扱う項目を適切に取り扱う必要があるため。