### PR TITLE
ユーザー新規登録完了→登録完了画面の遷移を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
+
+  def after_sign_in_path_for(resource)
+    logs_path
+  end
   
   private
 


### PR DESCRIPTION
# What
application.controllerにDeviseのユーザー登録が完了した後、登録完了画面(logsのindex)にリダイレクトをさせる設定を追加します。

# Why
登録完了のビューは実装できていたが、画面遷移は未実装だったため