### PR TITLE
DB設計変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Things you may want to cover:
 |last_name_kana  |string    |null: false|
 |first_name_kana |string    |null: false|
 |postal_code     |integer   |null: false|
-|prefecture_id   |integer   |null: false, foreign_key: true|
+|prefecture_id   |string    |null: false|
 |city            |string    |null: false|
 |block           |string    |null: false|
 |building        |string    |null: false|
@@ -95,13 +95,13 @@ Things you may want to cover:
 |seller_id           |references |null: false, foreign_key: true|
 |buyer_id            |references |null: false, foreign_key: true|
 |product_category_id |references |null: false, foreign_key: true|
-|product_condition_id|references |null: false, foreign_key: true|
-|postage_way_id      |references |null: false, foreign_key: true|
+|product_condition_id|string     |null: false|
+|postage_way_id      |string     |null: false|
 |postage             |string     |null: false|
-|shipping_day_id     |references |null: false, foreign_key: true|
+|shipping_day_id     |string     |null: false|
 |product_brand_id    |references |foreign_key: true|
-|product_size_id     |references |foreign_key: true|
-|prefecture_id       |references |null: false, foreign_key: true|
+|product_size_id     |string     |           |
+|prefecture_id       |string     |null: false|
 
 ### Association
 - has_many :product_images, dependent: :destroy


### PR DESCRIPTION
# what
active_hashに関してoptionの外部キー制約削除
下記テーブルのカラムの型変更
destination table
　prefecture_id string型へ

products table
　prefecture_id string型へ
　product_condition_id string型へ
　postage_way_id string型へ
　shipping_day_id  string型へ
　product_size_id string型へ

# why
productsテーブルとdestinationsテーブルを生成するため。
Active_hashを活用する項目に外部キー制約を付与した場合、テーブル生成ができないため。