### PR TITLE
商品出品画面へカテゴリ機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'mini_racer', platforms: :ruby
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
@@ -78,3 +78,4 @@ gem 'active_hash'
 gem 'payjp'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,10 @@ GEM
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kgio (2.11.3)
     libv8 (7.3.492.27.1)
     listen (3.1.5)
@@ -269,9 +273,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -316,6 +317,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mini_racer
@@ -328,7 +330,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn (= 5.4.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require activestorage
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/product_new.js
+++ b/app/assets/javascripts/product_new.js
@@ -8,7 +8,7 @@ function appendProductCategoryChildrenBox(insertHTML) {
   let productCategoryChildrenHtml = '';
   productCategoryChildrenHtml = 
     `<select class="putup__main__category__select-box" id="product_category_children">
-       <option value="">選択してください</option>
+       <option value="" data-category="">選択してください</option>
        ${insertHTML}</select>`;
   $('#children_box').append(productCategoryChildrenHtml);
 }
@@ -17,7 +17,7 @@ function appendProductCategoryGrandchildrenBox(insertHTML) {
   let productCategoryGrandChildrenHtml = '';
   productCategoryGrandChildrenHtml = 
     `<select class="putup__main__category__select-box" id="product_category_grandchildren" name="item[category_id]">
-       <option value="">選択してください</option>
+       <option value="" data-category="">選択してください</option>
        ${insertHTML}</select>`;
   $('#grandchildren_box').append(productCategoryGrandChildrenHtml);
 }

--- a/app/assets/javascripts/product_new.js
+++ b/app/assets/javascripts/product_new.js
@@ -1,0 +1,77 @@
+function appendOption(category) {
+  let html = 
+    `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
+  return html;
+}
+
+function appendProductCategoryChildrenBox(insertHTML) {
+  let productCategoryChildrenHtml = '';
+  productCategoryChildrenHtml = 
+    `<select class="putup__main__category__select-box" id="product_category_children">
+       <option value="">選択してください</option>
+       ${insertHTML}</select>`;
+  $('#children_box').append(productCategoryChildrenHtml);
+}
+
+function appendProductCategoryGrandchildrenBox(insertHTML) {
+  let productCategoryGrandChildrenHtml = '';
+  productCategoryGrandChildrenHtml = 
+    `<select class="putup__main__category__select-box" id="product_category_grandchildren" name="item[category_id]">
+       <option value="">選択してください</option>
+       ${insertHTML}</select>`;
+  $('#grandchildren_box').append(productCategoryGrandChildrenHtml);
+}
+
+$(document).on("change","#product_category_parent", function() {
+  let productParentCategory =  $("#product_category_parent").val();
+  if (productParentCategory != "") {
+    $.ajax( {
+      type: 'GET',
+      url: 'get_product_category_children',
+      data: { product_category_parent_name: productParentCategory },
+      dataType: 'json'
+    })
+    .done(function(children) {
+      $("#children_box").empty();
+      $("#grandchildren_box").empty();
+      let insertHTML = '';
+      children.forEach(function(child) {
+        insertHTML += appendOption(child);
+      });
+      appendProductCategoryChildrenBox(insertHTML);
+    })
+    .fail(function() {
+      alert('商品子カテゴリーの取得に失敗');
+    })
+  }else{
+    $("#children_box").empty();
+    $("#grandchildren_box").empty();
+  }
+});
+
+$(document).on('change', '#children_box', function() {
+  let child_id = $('#product_category_children option:selected').data('category');
+  if (child_id != ""){
+    $.ajax({
+      url: 'get_product_category_grandchildren',
+      type: 'GET',
+      data: { product_category_child_id: child_id },
+      datatype: 'json'
+    })
+    .done(function(grandchildren) {
+      if (grandchildren.length != 0) {
+        $("#grandchildren_box").empty();
+        let insertHTML = '';
+        grandchildren.forEach(function(grandchild) {
+          insertHTML += appendOption(grandchild);
+        });
+        appendProductCategoryGrandchildrenBox(insertHTML);
+      }
+    })
+    .fail(function() {
+      alert('商品孫カテゴリーの取得に失敗');
+    })
+  }else{
+    $("#grandchildren_box").empty();
+  }
+});

--- a/app/assets/stylesheets/pages/_products_new.scss
+++ b/app/assets/stylesheets/pages/_products_new.scss
@@ -115,6 +115,10 @@
       border-color: #DDDDDD;
       border-radius: 5px;
     }
+    &__select-box--children{
+    }
+    &__select-box--grandchildren{
+    }
   }
   &__brand{
     padding-top: 40px;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,11 +1,34 @@
 class ProductsController < ApplicationController
+  before_action :set_product_category_parent, only: :new
 
   def new
+    @product = Product.new
   end
 
   def show
   end
   
   def purchase
+  end
+
+  # 親カテゴリーに紐づく子カテゴリーの配列を取得
+  def get_product_category_children
+    @product_category_children = ProductCategory.find(params[:product_category_parent_name]).children
+  end
+
+  # 子カテゴリーに紐づく孫カテゴリーの配列を取得
+  def get_product_category_grandchildren
+    @product_category_grandchildren = ProductCategory.find("#{params[:product_category_child_id]}").children
+  end
+
+private
+
+  # 親カテゴリーの配列を取得
+  def set_product_category_parent  
+    @product_category_parents = ProductCategory.where(ancestry: nil)
+  end
+
+  def product_params
+    params.require(:product).permit(:name,:description,:price,:seller_id,:buyer_id,:product_category_id,:product_condition_id,:postage_way_id,:postage,:shipping_day_id,:product_brand_id,:product_size_id,:prefecture_id)
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,8 +9,6 @@
     
     = csrf_meta_tags
     = csp_meta_tag
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,7 +9,9 @@
     
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = yield

--- a/app/views/products/get_product_category_children.json.jbuilder
+++ b/app/views/products/get_product_category_children.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @product_category_children do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/products/get_product_category_grandchildren.json.jbuilder
+++ b/app/views/products/get_product_category_grandchildren.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @product_category_grandchildren do |grandchild|
+  json.id grandchild.id
+  json.name grandchild.name
+end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -3,185 +3,184 @@
     = render "header_products"
 
   .putup__main
-    .putup__main__upload
-      %label.putup__main__upload__title
-        出品画像
-        %span.putup__main__upload__title__imperative
-          必須
-      %p.putup__main__upload__description
-        最大10枚までアップロードできます
-      %textarea{class: "putup__main__upload__image-box", rows: "5", placeholder:'ドラッグアンドドロップまたはクリックしてファイルをアップロード'}
+    = form_for @product do |f|
+      .putup__main__upload
+        %label.putup__main__upload__title
+          出品画像
+          %span.putup__main__upload__title__imperative
+            必須
+        %p.putup__main__upload__description
+          最大10枚までアップロードできます
+        %textarea{class: "putup__main__upload__image-box", rows: "5", placeholder:'ドラッグアンドドロップまたはクリックしてファイルをアップロード'}
 
-    %hr.putup__main__separate-line
+      %hr.putup__main__separate-line
 
-    .putup__main__name
-      %p.putup__main__name__title
-        商品名
-        %span.putup__main__name__title__imperative
-          必須
-      %input{type: "text", class: "putup__main__name__text-box", placeholder:'40文字まで'}
+      .putup__main__name
+        %p.putup__main__name__title
+          商品名
+          %span.putup__main__name__title__imperative
+            必須
+        %input{type: "text", class: "putup__main__name__text-box", placeholder:'40文字まで'}
 
-    .putup__main__description 
-      %p.putup__main__description__title
-        商品の説明
-        %span.putup__main__description__title__imperative
-          必須
-      %textarea{class: "putup__main__description__text-box", rows: "6", 
-      placeholder:'商品の説明（必須 1,000文字以内）,
-      （色、素材、重さ、定価、注意点など）,
-      ,
-      例）2010年頃に1万円で購入したジャケットです。,
-      ライトグレーで傷はありません。あわせやすいのでおすすめです。'}
+      .putup__main__description 
+        %p.putup__main__description__title
+          商品の説明
+          %span.putup__main__description__title__imperative
+            必須
+        %textarea{class: "putup__main__description__text-box", rows: "6", 
+        placeholder:'商品の説明（必須 1,000文字以内）,
+        （色、素材、重さ、定価、注意点など）,
+        ,
+        例）2010年頃に1万円で購入したジャケットです。,
+        ライトグレーで傷はありません。あわせやすいのでおすすめです。'}
 
-    %hr.putup__main__separate-line
+      %hr.putup__main__separate-line
 
-    .putup__main__product-detail 
-      %p.putup__main__product-detail__title
-        商品の詳細
+      .putup__main__product-detail 
+        %p.putup__main__product-detail__title
+          商品の詳細
 
-    .putup__main__category 
-      %p.putup__main__category__title
-        カテゴリー
-        %span.putup__main__category__title__imperative
-          必須
-      %select{class: "putup__main__category__select-box"}
-        %option{:value => "0"}  選択してください
-        %option{:value => "1"}  レディース
-        %option{:value => "2"}  メンズ
-        -# gem ancestryでカテゴリを実装予定(仮実装)
+      .putup__main__category 
+        %p.putup__main__category__title
+          カテゴリー
+          %span.putup__main__category__title__imperative
+            必須
+        = f.collection_select :product_category_id, ProductCategory.where(id: 1..13), :id, :name,  {prompt: '選択してください'},{class: "putup__main__category__select-box",id: "product_category_parent"}
+        .putup__main__category__select-box--children#children_box
+        .putup__main__category__select-box--grandchildren#grandchildren_box
 
-    .putup__main__brand
-      %p.putup__main__brand__title
-        ブランド
-        %span.putup__main__brand__title__optional
-          任意
-      %input{type: "text", class: "putup__main__brand__text-box", placeholder:'例）シャネル'}
+      .putup__main__brand
+        %p.putup__main__brand__title
+          ブランド
+          %span.putup__main__brand__title__optional
+            任意
+        %input{type: "text", class: "putup__main__brand__text-box", placeholder:'例）シャネル'}
 
-    .putup__main__condition
-      %p.putup__main__condition__title
-        商品の状態
-        %span.putup__main__condition__title__imperative
-          必須
-      %select{class: "putup__main__condition__select-box"}
-        %option{:value => "0"}  選択してください
-        %option{:value => "1"}  新品、未使用
-        %option{:value => "2"}  未使用に近い
-        %option{:value => "3"}  目立った傷や汚れなし
-        %option{:value => "4"}  やや傷や汚れあり
-        %option{:value => "5"}  傷や汚れあり
-        %option{:value => "6"}  全体的に状態が悪い
-        -# active_hashで商品の状態を実装予定(仮実装)
+      .putup__main__condition
+        %p.putup__main__condition__title
+          商品の状態
+          %span.putup__main__condition__title__imperative
+            必須
+        %select{class: "putup__main__condition__select-box"}
+          %option{:value => "0"}  選択してください
+          %option{:value => "1"}  新品、未使用
+          %option{:value => "2"}  未使用に近い
+          %option{:value => "3"}  目立った傷や汚れなし
+          %option{:value => "4"}  やや傷や汚れあり
+          %option{:value => "5"}  傷や汚れあり
+          %option{:value => "6"}  全体的に状態が悪い
+          -# active_hashで商品の状態を実装予定(仮実装)
 
-    %hr.putup__main__separate-line
+      %hr.putup__main__separate-line
 
-    .putup__main__delivery 
-      %p.putup__main__delivery__title
-        配送について
-        = link_to "?", 'https://www.mercari.com/jp/help_center/article/68/', class:"putup__main__delivery__title__icon" 
+      .putup__main__delivery 
+        %p.putup__main__delivery__title
+          配送について
+          = link_to "?", 'https://www.mercari.com/jp/help_center/article/68/', class:"putup__main__delivery__title__icon" 
 
-    .putup__main__postage-way
-      %p.putup__main__postage-way__title
-        配送料の負担
-        %span.putup__main__postage-way__title__imperative
-          必須
-      %select{class: "putup__main__postage-way__select-box"}
-        %option{:value => "0"}  選択してください
-        %option{:value => "1"}  送料込み(出品者負担)
-        %option{:value => "2"}  着払い(購入者負担)
-        -# active_hashで配送料の負担を実装予定(仮実装)
+      .putup__main__postage-way
+        %p.putup__main__postage-way__title
+          配送料の負担
+          %span.putup__main__postage-way__title__imperative
+            必須
+        %select{class: "putup__main__postage-way__select-box"}
+          %option{:value => "0"}  選択してください
+          %option{:value => "1"}  送料込み(出品者負担)
+          %option{:value => "2"}  着払い(購入者負担)
+          -# active_hashで配送料の負担を実装予定(仮実装)
 
-    .putup__main__prefecture
-      %p.putup__main__prefecture__title
-        発送元の地域
-        %span.putup__main__prefecture__title__imperative
-          必須
-      %select{class: "putup__main__prefecture__select-box"}
-        %option{:value => "0"}  選択してください
-        %option{:value => "1"}  北海道
-        %option{:value => "2"}  青森
-        -# active_hashで都道府県を実装予定(仮実装)
+      .putup__main__prefecture
+        %p.putup__main__prefecture__title
+          発送元の地域
+          %span.putup__main__prefecture__title__imperative
+            必須
+        %select{class: "putup__main__prefecture__select-box"}
+          %option{:value => "0"}  選択してください
+          %option{:value => "1"}  北海道
+          %option{:value => "2"}  青森
+          -# active_hashで都道府県を実装予定(仮実装)
 
-    .putup__main__shipping-day
-      %p.putup__main__shipping-day__title
-        発送までの日数
-        %span.putup__main__shipping-day__title__imperative
-          必須
-      %select{class: "putup__main__shipping-day__select-box"}
-        %option{:value => "0"}  選択してください
-        %option{:value => "1"}  1〜2日で発送
-        %option{:value => "2"}  2〜3日で発送
-        %option{:value => "3"}  4〜7日で発送
-        -# active_hashで発送までの日数を実装予定(仮実装)
+      .putup__main__shipping-day
+        %p.putup__main__shipping-day__title
+          発送までの日数
+          %span.putup__main__shipping-day__title__imperative
+            必須
+        %select{class: "putup__main__shipping-day__select-box"}
+          %option{:value => "0"}  選択してください
+          %option{:value => "1"}  1〜2日で発送
+          %option{:value => "2"}  2〜3日で発送
+          %option{:value => "3"}  4〜7日で発送
+          -# active_hashで発送までの日数を実装予定(仮実装)
 
-    %hr.putup__main__separate-line
+      %hr.putup__main__separate-line
 
-    .putup__main__price-range
-      %p.putup__main__price-range__title
-        価格（¥300〜9,999,999）
-        = link_to "?", 'https://www.mercari.com/jp/help_center/article/64/', class:"putup__main__price-range__title__icon" 
+      .putup__main__price-range
+        %p.putup__main__price-range__title
+          価格（¥300〜9,999,999）
+          = link_to "?", 'https://www.mercari.com/jp/help_center/article/64/', class:"putup__main__price-range__title__icon" 
 
-    .putup__main__price
-      %ul.putup__main__price__contents
-        %li.putup__main__price__contents__content
-          .putup__main__price__contents__content__frame
-            .putup__main__price__contents__content__frame__title-box
-              %label.putup__main__price__contents__content__frame__title-box__title
-                販売価格
-                %span.putup__main__price__contents__content__frame__title-box__title__imperative
-                  必須
-            .putup__main__price__contents__content__frame__input
-              %p.putup__main__price__contents__content__frame__input__yen
-                ¥
-              %input{type: "number",min: "300", max: "9999999", class: "putup__main__price__contents__content__frame__input__number-box", placeholder:'0'}
+      .putup__main__price
+        %ul.putup__main__price__contents
+          %li.putup__main__price__contents__content
+            .putup__main__price__contents__content__frame
+              .putup__main__price__contents__content__frame__title-box
+                %label.putup__main__price__contents__content__frame__title-box__title
+                  販売価格
+                  %span.putup__main__price__contents__content__frame__title-box__title__imperative
+                    必須
+              .putup__main__price__contents__content__frame__input
+                %p.putup__main__price__contents__content__frame__input__yen
+                  ¥
+                %input{type: "number",min: "300", max: "9999999", class: "putup__main__price__contents__content__frame__input__number-box", placeholder:'0'}
 
-    .putup__main__commission
-      %ul.putup__main__commission__contents
-        %li.putup__main__commission__contents__content
-          .putup__main__commission__contents__content__frame
-            .putup__main__commission__contents__content__frame__title-box
-              %label.putup__main__commission__contents__content__frame__title-box__title
-                販売手数料（10%）
-            .putup__main__commission__contents__content__frame__input
-              %p.putup__main__commission__contents__content__frame__input__calc-result
-                ー
+      .putup__main__commission
+        %ul.putup__main__commission__contents
+          %li.putup__main__commission__contents__content
+            .putup__main__commission__contents__content__frame
+              .putup__main__commission__contents__content__frame__title-box
+                %label.putup__main__commission__contents__content__frame__title-box__title
+                  販売手数料（10%）
+              .putup__main__commission__contents__content__frame__input
+                %p.putup__main__commission__contents__content__frame__input__calc-result
+                  ー
 
-    %hr.putup__main__separate-line
+      %hr.putup__main__separate-line
 
-    .putup__main__profit
-      %ul.putup__main__profit__contents
-        %li.putup__main__profit__contents__content
-          .putup__main__profit__contents__content__frame
-            .putup__main__profit__contents__content__frame__title-box
-              %label.putup__main__profit__contents__content__frame__title-box__title
-                販売利益
-            .putup__main__profit__contents__content__frame__input
-              %p.putup__main__profit__contents__content__frame__input__calc-result
-                ー
+      .putup__main__profit
+        %ul.putup__main__profit__contents
+          %li.putup__main__profit__contents__content
+            .putup__main__profit__contents__content__frame
+              .putup__main__profit__contents__content__frame__title-box
+                %label.putup__main__profit__contents__content__frame__title-box__title
+                  販売利益
+              .putup__main__profit__contents__content__frame__input
+                %p.putup__main__profit__contents__content__frame__input__calc-result
+                  ー
 
-    .putup__main__submit
-      %input{type: "submit", class: "putup__main__submit__submit-btn", value:'出品する'}
+      .putup__main__submit
+        %input{type: "submit", class: "putup__main__submit__submit-btn", value:'出品する'}
 
-    .putup__main__draft
-      %input{type: "submit", class: "putup__main__draft__submit-btn", value:'下書きに保存'}
+      .putup__main__draft
+        %input{type: "submit", class: "putup__main__draft__submit-btn", value:'下書きに保存'}
 
-    .putup__main__page-transition
-      %p.putup__main__page-transition__title
-        = link_to "#", class: "putup__main__page-transition__title__link" do
-          もどる
+      .putup__main__page-transition
+        %p.putup__main__page-transition__title
+          = link_to "#", class: "putup__main__page-transition__title__link" do
+            もどる
 
-    .putup__main__prohibit
-      %p.putup__main__prohibit__script
-        禁止されている
-        = link_to "行為", 'https://www.mercari.com/jp/help_center/getting_started/prohibited_conduct/', class:"putup__main__prohibit__script__action"
-        および
-        = link_to "出品物", 'https://www.mercari.com/jp/help_center/getting_started/prohibited_items/', class:"putup__main__prohibit__script__action"
-        を必ずご確認ください。
-        = link_to "偽ブランド品", 'https://www.mercari.com/jp/help_center/getting_started/counterfeit_goods/', class:"putup__main__prohibit__script__action"
-        や
-        = link_to "盗品物", 'https://www.mercari.com/jp/help_center/getting_started/report_counterfeit_goods/', class:"putup__main__prohibit__script__action"
-        などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして
-        = link_to "加盟店規約", 'https://www.mercari.com/jp/seller_terms/', class:"putup__main__prohibit__script__action"
-        に同意したことになります。
+      .putup__main__prohibit
+        %p.putup__main__prohibit__script
+          禁止されている
+          = link_to "行為", 'https://www.mercari.com/jp/help_center/getting_started/prohibited_conduct/', class:"putup__main__prohibit__script__action"
+          および
+          = link_to "出品物", 'https://www.mercari.com/jp/help_center/getting_started/prohibited_items/', class:"putup__main__prohibit__script__action"
+          を必ずご確認ください。
+          = link_to "偽ブランド品", 'https://www.mercari.com/jp/help_center/getting_started/counterfeit_goods/', class:"putup__main__prohibit__script__action"
+          や
+          = link_to "盗品物", 'https://www.mercari.com/jp/help_center/getting_started/report_counterfeit_goods/', class:"putup__main__prohibit__script__action"
+          などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして
+          = link_to "加盟店規約", 'https://www.mercari.com/jp/seller_terms/', class:"putup__main__prohibit__script__action"
+          に同意したことになります。
 
   .putup__footer
     = render "footer_products"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,19 @@ Rails.application.routes.draw do
   root "tops#index"
   resources :users ,only: :new
   resources :logs ,only: :index
-  resources :products ,only: [:new, :show] do
+  resources :products do
     collection do
       get 'purchase'
+    end
+    # :idなし
+    collection do
+      get 'get_product_category_children', defaults: { format: 'json' }
+      get 'get_product_category_grandchildren', defaults: { format: 'json' }
+    end
+    # :idあり
+    member do
+      get 'get_product_category_children', defaults: { format: 'json' }
+      get 'get_product_category_grandchildren', defaults: { format: 'json' }
     end
   end
 end


### PR DESCRIPTION
# what
　gem jquery-rails追加
　jquery追加
　turbolinksの削除

　コントローラーに商品の子・孫カテゴリーの定義追加

　product_new.js 実装
　　動的に商品の子・孫カテゴリーを表示

# why
ユーザーが出品時に必須項目であるカテゴリーを選択する際に、
親カテゴリーを選択すると、連動する子カテゴリー、孫カテゴリーを非同期で表示するため。