### PR TITLE
DB設計変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Things you may want to cover:
 |prefecture_id   |string    |null: false|
 |city            |string    |null: false|
 |block           |string    |null: false|
-|building        |string    |null: false|
+|building        |string    |           |
 |phone_number    |string    |           |
 |user_id         |references|null: false, foreign_key: true|
 
@@ -93,14 +93,13 @@ Things you may want to cover:
 |description         |text       |null: false|
 |price               |integer    |null: false|
 |seller_id           |references |null: false, foreign_key: true|
-|buyer_id            |references |null: false, foreign_key: true|
+|buyer_id            |references |             foreign_key: true|
 |product_category_id |references |null: false, foreign_key: true|
 |product_condition_id|string     |null: false|
 |postage_way_id      |string     |null: false|
-|postage             |string     |null: false|
 |shipping_day_id     |string     |null: false|
-|product_brand_id    |references |foreign_key: true|
-|product_size_id     |string     |           |
+|product_brand_id    |references |             foreign_key: true|
+|product_size_id     |string     |null: false|
 |prefecture_id       |string     |null: false|
 
 ### Association
@@ -121,7 +120,7 @@ Things you may want to cover:
 ## product_images table
 |Column     |Type       |Options    |
 |-----------|-----------|-----------|
-|image      |text       |null: false|
+|image      |string     |null: false|
 |product_id |references |null: false, foreign_key: true|
 
 ### Association

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -70,7 +70,7 @@
               %span
                 (税込)
               %span
-                = @product.postage
+                = @product.postage_way_id
 
           .show__main__product__content__information__introduction
             = @product.description

--- a/db/migrate/20200626102142_remove_postage_from_products.rb
+++ b/db/migrate/20200626102142_remove_postage_from_products.rb
@@ -1,0 +1,5 @@
+class RemovePostageFromProducts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :products, :postage, :string
+  end
+end

--- a/db/migrate/20200626103705_change_column_to_allow_null.rb
+++ b/db/migrate/20200626103705_change_column_to_allow_null.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToAllowNull < ActiveRecord::Migration[5.2]
+  def up
+    change_column :destinations, :building,:string, null: true
+  end
+
+  def down
+    change_column :destinations, :building,:string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_15_042351) do
+ActiveRecord::Schema.define(version: 2020_06_26_103705) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment", null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2020_06_15_042351) do
     t.string "prefecture_id", null: false
     t.string "city", null: false
     t.string "block", null: false
-    t.string "building", null: false
+    t.string "building"
     t.string "phone_number"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -87,7 +87,6 @@ ActiveRecord::Schema.define(version: 2020_06_15_042351) do
     t.bigint "product_category_id", null: false
     t.string "product_condition_id", null: false
     t.string "postage_way_id", null: false
-    t.string "postage", null: false
     t.string "shipping_day_id", null: false
     t.bigint "product_brand_id"
     t.string "product_size_id", null: false


### PR DESCRIPTION
# what
DB設計を最新化

destination table
　building NOT NULL制約を除外（任意項目のため）
product table
　buyer_id NOT NULL制約を除外（商品出品時に登録不要のため）
　product_brand_id NOT NULL制約を除外
　postage 削除（postage_way_idと機能が重複しているため）
product_image table
　image string型へ更新

postageカラム削除のためカラム削除用マイグレファイル追加
　商品詳細ページのpostage使用箇所もあわせて修正
buildingカラムのNOT NULL制約を除外するためマイグレファイル追加

# why
プログラムと設計を一致させるため。
