### PR TITLE
サイズ機能を出品画面へ追加

### DIFF
--- a/app/assets/javascripts/product_new.js
+++ b/app/assets/javascripts/product_new.js
@@ -22,6 +22,22 @@ function appendProductCategoryGrandchildrenBox(insertHTML) {
   $('#grandchildren_box').append(productCategoryGrandChildrenHtml);
 }
 
+function appendProductSizeBox(insertHTML) {
+  let productSizeHtml = '';
+  productSizeHtml = 
+    `<div class='putup__main__size'>
+     <p class='putup__main__size__title'>
+     サイズ
+     <span class='putup__main__size__title__imperative'>
+     必須
+     </span>
+     </p>
+     <select class="putup__main__size__select-box" id="product_size">
+     <option value="">選択してください</option>${insertHTML}</select>
+     </div>`;
+  $('#size_box').append(productSizeHtml);
+}
+
 $(document).on("change","#product_category_parent", function() {
   let productParentCategory =  $("#product_category_parent").val();
   if (productParentCategory != "") {
@@ -34,6 +50,7 @@ $(document).on("change","#product_category_parent", function() {
     .done(function(children) {
       $("#children_box").empty();
       $("#grandchildren_box").empty();
+      $("#size_box").empty();
       let insertHTML = '';
       children.forEach(function(child) {
         insertHTML += appendOption(child);
@@ -46,9 +63,9 @@ $(document).on("change","#product_category_parent", function() {
   }else{
     $("#children_box").empty();
     $("#grandchildren_box").empty();
+    $("#size_box").empty();
   }
 });
-
 $(document).on('change', '#children_box', function() {
   let child_id = $('#product_category_children option:selected').data('category');
   if (child_id != ""){
@@ -61,6 +78,7 @@ $(document).on('change', '#children_box', function() {
     .done(function(grandchildren) {
       if (grandchildren.length != 0) {
         $("#grandchildren_box").empty();
+        $("#size_box").empty();
         let insertHTML = '';
         grandchildren.forEach(function(grandchild) {
           insertHTML += appendOption(grandchild);
@@ -73,5 +91,48 @@ $(document).on('change', '#children_box', function() {
     })
   }else{
     $("#grandchildren_box").empty();
+    $("#size_box").empty();
   }
 });
+
+$(document).on('change', '#grandchildren_box', function() {
+  let child_id = $('#product_category_children option:selected').data('category');
+  let grandchildId = $('#product_category_grandchildren option:selected').data('category');
+
+  if(clothesShoeJudgement(child_id, grandchildId) != ""){
+    $.ajax({
+      url: 'get_product_size',
+      type: 'GET',
+      data: { product_size_id: clothes_shoe_judgement_val },
+      datatype: 'json'
+    })
+    .done(function(sizes) {
+      $("#size_box").empty();
+      let insertHTML = '';
+      sizes.forEach(function(size) {
+        insertHTML += appendOption(size);
+      });
+      appendProductSizeBox(insertHTML);
+  })
+  .fail(function() {
+    alert('商品サイズの取得に失敗');
+  })
+  }else{
+    $("#size_box").empty();
+  }
+});
+
+function clothesShoeJudgement(child, grandchild) {
+  clothes_size_array     = [14, 29, 44, 57, 63, 79, 150, 163, 178, 210, 255];
+  Ladies_shoe_size_array = [68, 82];
+  Mens_shoe_size_array   = [188, 260];
+  if (clothes_size_array.includes(child) || clothes_size_array.includes(grandchild)){
+    return clothes_shoe_judgement_val = 1;
+  }else if(Ladies_shoe_size_array.includes(child) || Ladies_shoe_size_array.includes(grandchild)){
+    return clothes_shoe_judgement_val = 2;
+  }else if(Mens_shoe_size_array.includes(child) || Mens_shoe_size_array.includes(grandchild)){
+    return clothes_shoe_judgement_val = 3;
+  }else{
+    return clothes_shoe_judgement_val = "";
+  }
+}

--- a/app/assets/stylesheets/pages/_products_new.scss
+++ b/app/assets/stylesheets/pages/_products_new.scss
@@ -36,9 +36,7 @@
       }
       &__image-box{
         margin: 20px 40px 0px 40px;
-        // border-style: dashed;
         width: calc(100% - 80px);
-        // background-color: whitesmoke;
       }
   }
   &__name{

--- a/app/assets/stylesheets/pages/_products_new.scss
+++ b/app/assets/stylesheets/pages/_products_new.scss
@@ -36,9 +36,9 @@
       }
       &__image-box{
         margin: 20px 40px 0px 40px;
-        border-style: dashed;
+        // border-style: dashed;
         width: calc(100% - 80px);
-        background-color: whitesmoke;
+        // background-color: whitesmoke;
       }
   }
   &__name{
@@ -118,6 +118,27 @@
     &__select-box--children{
     }
     &__select-box--grandchildren{
+    }
+  }
+  &__size{
+    padding-top: 40px;
+    &__title{
+      margin-left: 40px;
+      font-weight: bold;
+      font-size: 14px;
+      &__imperative{
+        border-radius: 2px;
+        padding: 2px 4px;
+        font-size: 12px;
+        background-color:#99FFFF;
+      }
+    }
+    &__select-box{
+      margin: 20px 40px 0px 40px;
+      height: 40px;
+      width: calc(100% - 80px);
+      border-color: #DDDDDD;
+      border-radius: 5px;
     }
   }
   &__brand{

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,6 +31,11 @@ class ProductsController < ApplicationController
     @product_category_grandchildren = ProductCategory.find("#{params[:product_category_child_id]}").children
   end
 
+  # サイズの配列を取得
+  def get_product_size
+    @product_sizes = ProductSize.find_all_by_group "#{params[:product_size_id]}"
+  end
+
 private
 
   # 親カテゴリーの配列を取得

--- a/app/models/product_size.rb
+++ b/app/models/product_size.rb
@@ -1,14 +1,51 @@
 class ProductSize < ActiveHash::Base
   self.data = [
-      {id: 1, name: 'XXS以下'}, 
-      {id: 2, name: 'XS(SS)'}, 
-      {id: 3, name: 'S'},
-      {id: 4, name: 'M'},
-      {id: 5, name: 'L'},
-      {id: 6, name: 'XL(LL)'},
-      {id: 7, name: '2XL(3L)'},
-      {id: 8, name: '3XL(4L)'},
-      {id: 9, name: '4XL(5L)以上'},
-      {id: 10, name: 'FREE SIZE'}
+    # Clothes size
+      {id: 1, name: 'XXS以下',     group: '1'}, 
+      {id: 2, name: 'XS(SS)',     group: '1'}, 
+      {id: 3, name: 'S',          group: '1'},
+      {id: 4, name: 'M',          group: '1'},
+      {id: 5, name: 'L',          group: '1'},
+      {id: 6, name: 'XL(LL)',     group: '1'},
+      {id: 7, name: '2XL(3L)',    group: '1'},
+      {id: 8, name: '3XL(4L)',    group: '1'},
+      {id: 9, name: '4XL(5L)以上', group: '1'},
+      {id: 10, name: 'FREE SIZE', group: '1'},
+
+      # Ladies shoe size
+      { id: 11, name: '20cm以下',   group: '2' },
+      { id: 12, name: '20.5cm',    group: '2' },
+      { id: 13, name: '21cm',      group: '2' },
+      { id: 14, name: '21.5cm',    group: '2' },
+      { id: 15, name: '22cm',      group: '2' },
+      { id: 16, name: '22.5cm',    group: '2' },
+      { id: 17, name: '23cm',      group: '2' },
+      { id: 18, name: '23.5cm',    group: '2' },
+      { id: 19, name: '24cm',      group: '2' },
+      { id: 20, name: '24.5cm',    group: '2' },
+      { id: 21, name: '25cm',      group: '2' },
+      { id: 22, name: '25.5cm',    group: '2' },
+      { id: 23, name: '26cm',      group: '2' },
+      { id: 24, name: '26.5cm',    group: '2' },
+      { id: 25, name: '27cm',      group: '2' },
+      { id: 26, name: '27.5cm以上', group: '2' },
+
+      # Mens shoe size
+      { id: 27, name: '23.5cm以下', group: '3' },
+      { id: 28, name: '24cm',      group: '3' },
+      { id: 29, name: '24.5cm',    group: '3' },
+      { id: 30, name: '25cm',      group: '3' },
+      { id: 31, name: '25.5cm',    group: '3' },
+      { id: 32, name: '26cm',      group: '3' },
+      { id: 33, name: '26.5cm',    group: '3' },
+      { id: 34, name: '27cm',      group: '3' },
+      { id: 35, name: '27.5cm',    group: '3' },
+      { id: 36, name: '28cm',      group: '3' },
+      { id: 37, name: '28.5cm',    group: '3' },
+      { id: 38, name: '29cm',      group: '3' },
+      { id: 39, name: '29.5cm',    group: '3' },
+      { id: 40, name: '30cm',      group: '3' },
+      { id: 41, name: '30.5cm',    group: '3' },
+      { id: 42, name: '31cm以上',   group: '3' }
     ]
 end

--- a/app/views/products/get_product_size.json.jbuilder
+++ b/app/views/products/get_product_size.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @product_sizes do |size|
+  json.id size.id
+  json.name size.name
+end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -48,6 +48,7 @@
         = f.collection_select :product_category_id, ProductCategory.where(id: 1..13), :id, :name,  {prompt: '選択してください'},{class: "putup__main__category__select-box",id: "product_category_parent"}
         .putup__main__category__select-box--children#children_box
         .putup__main__category__select-box--grandchildren#grandchildren_box
+        .putup__main__size__select-box--size#size_box
 
       .putup__main__brand
         %p.putup__main__brand__title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,11 +13,13 @@ Rails.application.routes.draw do
     collection do
       get 'get_product_category_children', defaults: { format: 'json' }
       get 'get_product_category_grandchildren', defaults: { format: 'json' }
+      get 'get_product_size', defaults: { format: 'json' }
     end
     # :idあり
     member do
       get 'get_product_category_children', defaults: { format: 'json' }
       get 'get_product_category_grandchildren', defaults: { format: 'json' }
+      get 'get_product_size', defaults: { format: 'json' }
     end
   end
 end


### PR DESCRIPTION
# what
出品画面へサイズ機能を追加

　product_new.js へサイズのボックスが非同期で表示されるよう追加
　_product_new.scssへサイズを追加
　product_controllerへサイズ取得定義の追加
　モデルproduct_sizeへ服と靴のサイズが別になるようグループ追加
　表示のためにjbuilder追加
　new.html.hamlへサイズボックスの追加
　routes.rbへサイズの記述追加

# why
購入者は服のサイズや靴のサイズ情報をもとに購入を決定する。
そのため、出品時にサイズ情報が必要な商品にはサイズを記述することを出品者への必須事項とするため。