### PR TITLE
[WIP]下書き保存機能の実装

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -1,0 +1,15 @@
+class Draft < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+  belongs_to_active_hash :product_condition
+  belongs_to_active_hash :postage_way
+  belongs_to_active_hash :shipping_day
+  belongs_to_active_hash :product_size
+  has_many :product_images, dependent: :destroy
+  belongs_to :seller, class_name: 'User', :foreign_key => 'seller_id'
+  belongs_to :buyer, class_name: 'User', :foreign_key => 'buyer_id', optional: true
+  belongs_to :product_category, optional: true
+  belongs_to :product_brand, optional: true
+  accepts_nested_attributes_for :product_images, allow_destroy: true
+
+end

--- a/db/migrate/20200719081641_create_drafts.rb
+++ b/db/migrate/20200719081641_create_drafts.rb
@@ -1,0 +1,19 @@
+class CreateDrafts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :drafts do |t|
+      t.string       :name
+      t.text         :description
+      t.integer      :price
+      t.references   :seller,                foreign_key: {to_table: :users}
+      t.references   :buyer,                 foreign_key: {to_table: :users}
+      t.references   :product_category,      foreign_key: true
+      t.string       :product_condition_id
+      t.string       :postage_way_id
+      t.string       :shipping_day_id
+      t.references   :product_brand,         foreign_key: true
+      t.string       :product_size_id
+      t.string       :prefecture_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_103705) do
+ActiveRecord::Schema.define(version: 2020_07_19_081641) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment", null: false
@@ -46,6 +46,27 @@ ActiveRecord::Schema.define(version: 2020_06_26_103705) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_destinations_on_user_id"
+  end
+
+  create_table "drafts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.integer "price"
+    t.bigint "seller_id"
+    t.bigint "buyer_id"
+    t.bigint "product_category_id"
+    t.string "product_condition_id"
+    t.string "postage_way_id"
+    t.string "shipping_day_id"
+    t.bigint "product_brand_id"
+    t.string "product_size_id"
+    t.string "prefecture_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["buyer_id"], name: "index_drafts_on_buyer_id"
+    t.index ["product_brand_id"], name: "index_drafts_on_product_brand_id"
+    t.index ["product_category_id"], name: "index_drafts_on_product_category_id"
+    t.index ["seller_id"], name: "index_drafts_on_seller_id"
   end
 
   create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -131,6 +152,10 @@ ActiveRecord::Schema.define(version: 2020_06_26_103705) do
   add_foreign_key "comments", "users"
   add_foreign_key "credit_cards", "users"
   add_foreign_key "destinations", "users"
+  add_foreign_key "drafts", "product_brands"
+  add_foreign_key "drafts", "product_categories"
+  add_foreign_key "drafts", "users", column: "buyer_id"
+  add_foreign_key "drafts", "users", column: "seller_id"
   add_foreign_key "favorites", "products"
   add_foreign_key "favorites", "users"
   add_foreign_key "product_images", "products"

--- a/spec/factories/drafts.rb
+++ b/spec/factories/drafts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :draft do
+    
+  end
+end

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Draft, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# what
ユーザーが商品出品中の情報を下書きとして保存できるようにするための機能

# why
商品出品は必須項目が多いため、出品情報投稿中に揃っているとは限らない。
ユーザーが途中まで編集した情報を保存しておくことで出品情報編集へのハードルが下がり、
ユーザビリティの向上に繋がるため。