### PR TITLE
商品詳細ページの画像プレビュー表示修正

### DIFF
--- a/app/assets/javascripts/product_show.js
+++ b/app/assets/javascripts/product_show.js
@@ -1,0 +1,23 @@
+$(function(){
+  // 最初の画像のみ半透明解除
+  $(".sub-image").first().css('opacity', '1');
+  // マウスオーバーの処理
+  $(".sub-image").mouseover(function(e){
+    let mainDataIndex = $(this).parent().attr('data-index')
+    $(".sub-image").each(function(){
+      let subDataIndex = $(this).parent().attr('data-index');
+      if (subDataIndex == mainDataIndex){
+        $(this).css('opacity', '1');
+      } else {
+        $(this).css('opacity', '0.5');
+      };
+    });
+    $(".show__main__product__content__information__image__top--list__item").each(function(index){
+      if(index == mainDataIndex){
+        $(this).css('z-index', 10);
+      } else {
+        $(this).css('z-index', 1);
+      };
+    });
+  });
+});

--- a/app/assets/javascripts/product_show.js
+++ b/app/assets/javascripts/product_show.js
@@ -16,7 +16,7 @@ $(function(){
       if(index == mainDataIndex){
         $(this).css('z-index', 10);
       } else {
-        $(this).css('z-index', 1);
+        $(this).css('z-index', -1);
       };
     });
   });

--- a/app/assets/stylesheets/pages/_products_show.scss
+++ b/app/assets/stylesheets/pages/_products_show.scss
@@ -42,6 +42,7 @@ a{
     margin: 0 auto;
     &__product{
       width: 700px;
+      
       margin: 0 auto;
       &__content{        
 
@@ -76,28 +77,37 @@ a{
             margin: 16px 0 0;
             position: relative;
             &__top{
-              width: 560px;
+              width: 460px;
+              height: 460px;
               margin: 0 auto;
-              display: flex;
               &--list{
-                img{
-                  height: 346px;
-                  width: 100%;
-                  object-fit: cover;
-                  vertical-align: bottom;
+                &__item{
+                  position: absolute;
+                  right: -100;
+                  width: 460px;
+                  img{
+                    height: 460px;
+                    width: 100%;
+                    object-fit: cover;
+                    vertical-align: bottom;
+                  }
                 }
               }
             }
             &__sub{
-              margin-top: 10px;
-              padding-left: 90px;
+              background-color: #F2F2F2;
+              margin: 0 auto;
+              padding-left: 25px;
               display: flex;
               flex-wrap: wrap;
               &--list{
-                width: 26%;
-                margin: 10px 10px 0 0;
+                width: 112px;
+                margin: 2px 2px 0 0;
+                .sub-image{
+                  opacity: 0.5 ;
+                }
                 img{
-                  height: 87px;
+                  height: 92px;
                   width: 100%;
                   object-fit: cover;
                   vertical-align: bottom;
@@ -108,7 +118,7 @@ a{
               &:before {
                 content: "";
                 position: absolute;
-                z-index: 10;
+                z-index: 100;
                 left: 30px;
                 top: 0;
                 border-bottom: 5em solid transparent;
@@ -120,7 +130,7 @@ a{
                 color: $white;
                 font-weight: bold;
                 letter-spacing: 2px;
-                z-index: 11;
+                z-index: 101;
                 left: 35px;
                 top: 18px;
                 -webkit-transform: rotate(-45deg);

--- a/app/assets/stylesheets/pages/_products_show.scss
+++ b/app/assets/stylesheets/pages/_products_show.scss
@@ -83,7 +83,6 @@ a{
               &--list{
                 &__item{
                   position: absolute;
-                  right: -100;
                   width: 460px;
                   img{
                     height: 460px;
@@ -102,7 +101,7 @@ a{
               flex-wrap: wrap;
               &--list{
                 width: 112px;
-                margin: 2px 2px 0 0;
+                margin: 2px 2px 2px 0px;
                 .sub-image{
                   opacity: 0.5 ;
                 }
@@ -119,7 +118,7 @@ a{
                 content: "";
                 position: absolute;
                 z-index: 100;
-                left: 30px;
+                left: 80px;
                 top: 0;
                 border-bottom: 5em solid transparent;
                 border-left: 5em solid $main-color;
@@ -131,7 +130,7 @@ a{
                 font-weight: bold;
                 letter-spacing: 2px;
                 z-index: 101;
-                left: 35px;
+                left: 85px;
                 top: 18px;
                 -webkit-transform: rotate(-45deg);
                 transform: rotate(-45deg);

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -40,41 +40,25 @@
               %li
                 = link_to "削除する", product_path(@product), class: "show__main__product__content__information__btn--delete", method: :delete
           -else
-          
-          -# 商品が存在しているか否かで売り切れ表示の場合分け
-          -if @product.buyer_id.present?
-            .show__main__product__content__information__image
-              .show__main__product__content__information__image__top
-                .show__main__product__content__information__image__top__stage
-                  .show__main__product__content__information__image__top--list
-                    - @product.product_images.each_with_index do |product_image,index|
-                      - if index == 0
-                        %div{class: "show__main__product__content__information__image__top--list__item" , data:{index: index}, style: "z-index:10;"}
-                          =image_tag product_image.image.url
-                      -else
-                        %div{class: "show__main__product__content__information__image__top--list__item", data:{index: index}, style: "z-index:1;"}
-                          =image_tag product_image.image.url
-              .show__main__product__content__information__image__sub
-                - @product.product_images.each_with_index do |product_image,index|
-                  %div{class: "show__main__product__content__information__image__sub--list", data:{index: index}}
-                    = image_tag product_image.image.url, {class: "sub-image"}
+
+          .show__main__product__content__information__image
+            .show__main__product__content__information__image__top
+              .show__main__product__content__information__image__top__stage
+                .show__main__product__content__information__image__top--list
+                  - @product.product_images.each_with_index do |product_image,index|
+                    - if index == 0
+                      %div{class: "show__main__product__content__information__image__top--list__item" , data:{index: index}, style: "z-index:10;"}
+                        =image_tag product_image.image.url
+                    -else
+                      %div{class: "show__main__product__content__information__image__top--list__item", data:{index: index}, style: "z-index:1;"}
+                        =image_tag product_image.image.url
+            .show__main__product__content__information__image__sub
+              - @product.product_images.each_with_index do |product_image,index|
+                %div{class: "show__main__product__content__information__image__sub--list", data:{index: index}}
+                  = image_tag product_image.image.url, {class: "sub-image"}
+            // 買い手がいたらSOLDOUTを付与
+            -if @product.buyer_id.present?
               .show__main__product__content__information__image--soldout
-          -else
-            .show__main__product__content__information__image
-              .show__main__product__content__information__image__top
-                .show__main__product__content__information__image__top__stage
-                  .show__main__product__content__information__image__top--list
-                    - @product.product_images.each_with_index do |product_image,index|
-                      - if index == 0
-                        %div{class: "show__main__product__content__information__image__top--list__item" , data:{index: index}, style: "z-index:10;"}
-                          =image_tag product_image.image.url
-                      -else
-                        %div{class: "show__main__product__content__information__image__top--list__item", data:{index: index}, style: "z-index:1;"}
-                          =image_tag product_image.image.url
-              .show__main__product__content__information__image__sub
-                - @product.product_images.each_with_index do |product_image,index|
-                  %div{class: "show__main__product__content__information__image__sub--list", data:{index: index}}
-                    = image_tag product_image.image.url, {class: "sub-image"}
 
           .show__main__product__content__information__price
             %span

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -44,25 +44,37 @@
           -# 商品が存在しているか否かで売り切れ表示の場合分け
           -if @product.buyer_id.present?
             .show__main__product__content__information__image
-              %ul.show__main__product__content__information__image__top
-                %li.show__main__product__content__information__image__top--list
-                  = image_tag @product.product_images[0].image.url
-              %ul.show__main__product__content__information__image__sub
-                - @product.product_images.each do |product_image|
-                  %li.show__main__product__content__information__image__sub--list
-                    = image_tag product_image.image.url
-                    
+              .show__main__product__content__information__image__top
+                .show__main__product__content__information__image__top__stage
+                  .show__main__product__content__information__image__top--list
+                    - @product.product_images.each_with_index do |product_image,index|
+                      - if index == 0
+                        %div{class: "show__main__product__content__information__image__top--list__item" , data:{index: index}, style: "z-index:10;"}
+                          =image_tag product_image.image.url
+                      -else
+                        %div{class: "show__main__product__content__information__image__top--list__item", data:{index: index}, style: "z-index:1;"}
+                          =image_tag product_image.image.url
+              .show__main__product__content__information__image__sub
+                - @product.product_images.each_with_index do |product_image,index|
+                  %div{class: "show__main__product__content__information__image__sub--list", data:{index: index}}
+                    = image_tag product_image.image.url, {class: "sub-image"}
               .show__main__product__content__information__image--soldout
-
           -else
             .show__main__product__content__information__image
-              %ul.show__main__product__content__information__image__top
-                %li.show__main__product__content__information__image__top--list
-                  = image_tag @product.product_images[0].image.url
-              %ul.show__main__product__content__information__image__sub
-                - @product.product_images.each do |product_image|
-                  %li.show__main__product__content__information__image__sub--list
-                    = image_tag product_image.image.url
+              .show__main__product__content__information__image__top
+                .show__main__product__content__information__image__top__stage
+                  .show__main__product__content__information__image__top--list
+                    - @product.product_images.each_with_index do |product_image,index|
+                      - if index == 0
+                        %div{class: "show__main__product__content__information__image__top--list__item" , data:{index: index}, style: "z-index:10;"}
+                          =image_tag product_image.image.url
+                      -else
+                        %div{class: "show__main__product__content__information__image__top--list__item", data:{index: index}, style: "z-index:1;"}
+                          =image_tag product_image.image.url
+              .show__main__product__content__information__image__sub
+                - @product.product_images.each_with_index do |product_image,index|
+                  %div{class: "show__main__product__content__information__image__sub--list", data:{index: index}}
+                    = image_tag product_image.image.url, {class: "sub-image"}
 
           .show__main__product__content__information__price
             %span


### PR DESCRIPTION
# What
商品詳細ページの画像プレビュー画面をよりメルカリに近づる試み
・小さい画像にカーソルをあわせたら、メインの大きなプレビューに画像が写るようにする

# Why
２枚目以降の画像が小さいプレビューしかないので、拡大して見れるようにするため