### PR TITLE
商品詳細画面の追加・修正

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,0 +1,5 @@
+module ProductsHelper
+  def converting_to_jpy(price)
+    "#{price.to_s(:delimited, delimiter: ',')} 円"
+  end
+end

--- a/app/helpers/tops_helper.rb
+++ b/app/helpers/tops_helper.rb
@@ -1,2 +1,5 @@
 module TopsHelper
+  def converting_to_jpy_top(price)
+    "#{price.to_s(:delimited, delimiter: ',')}"
+  end
 end

--- a/app/views/products/purchase.html.haml
+++ b/app/views/products/purchase.html.haml
@@ -20,8 +20,7 @@
                     = @product.name
                   %p.purchase__main__product-info__inner__content__detail__price
                     %span
-                      ¥
-                      = @product.price
+                      = converting_to_jpy(@product.price)
                     %span.purchase__main__product-info__inner__content__detail__price__tax
                       (税込)
                       %br/
@@ -34,8 +33,7 @@
                 .purchase__main__payment-info__innner__form__table__pay-label
                   支払い金額
                 .purchase__main__payment-info__innner__form__table__pay-amount
-                  ¥
-                  = @product.price
+                  = converting_to_jpy(@product.price)
 
               .purchase__main__payment-info__innner__form__user-info
                 %h3.purchase__main__payment-info__innner__form__user-info__pay-method

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -52,18 +52,20 @@
                     -else
                       %div{class: "show__main__product__content__information__image__top--list__item", data:{index: index}, style: "z-index:1;"}
                         =image_tag product_image.image.url
+
             .show__main__product__content__information__image__sub
               - @product.product_images.each_with_index do |product_image,index|
                 %div{class: "show__main__product__content__information__image__sub--list", data:{index: index}}
                   = image_tag product_image.image.url, {class: "sub-image"}
+
             // 買い手がいたらSOLDOUTを付与
             -if @product.buyer_id.present?
               .show__main__product__content__information__image--soldout
 
           .show__main__product__content__information__price
             %span
-              ¥
-              = @product.price
+              = converting_to_jpy(@product.price)
+              
             .show__main__product__content__information__price__detail
               %span
                 (税込)

--- a/app/views/tops/_item-preview.html.haml
+++ b/app/views/tops/_item-preview.html.haml
@@ -11,7 +11,7 @@
                 = truncate(product.name, length:15, omission: "...")
               .item__caption__details
                 .item__caption__details__price
-                  = product.price
+                  = converting_to_jpy_top(product.price)
                 %p.item__capiton__details__like
                   ★０
               %p.item__caption__tax (税込)
@@ -25,7 +25,7 @@
                 = truncate(product.name, length:15, omission: "...")
               .item__caption__details
                 .item__caption__details__price
-                  = product.price
+                  = converting_to_jpy_top(product.price)
                 %p.item__capiton__details__like
                   ★０
               %p.item__caption__tax (税込)

--- a/app/views/tops/_pickups.html.haml
+++ b/app/views/tops/_pickups.html.haml
@@ -20,7 +20,7 @@
             %h3.item__caption__name test-product
             .item__caption__details
               .item__caption__details__price
-                30000
+                30,000
               %p.item__capiton__details__like
                 ★０
             %p.item__caption__tax (税込)


### PR DESCRIPTION
# What
## 商品詳細表示画面の追加・修正を行う
### トップページ・商品詳細ページ・商品購入ページの商品価格に桁区切りを適用

# Why
## サイトの見やすさを向上させるため

＜トップページ＞
https://gyazo.com/44fcea0f8980e89c6e797235d2157381
＜商品詳細ページ＞
https://gyazo.com/a1e77d6c0fb74caf4c52ffae97c8ee32
＜商品購入ページ＞
https://gyazo.com/556c6f724cc564db74afab8d2d2c6709